### PR TITLE
fix: bump hh deploy and solc versions

### DIFF
--- a/cross-chain/L2-counter/package.json
+++ b/cross-chain/L2-counter/package.json
@@ -7,8 +7,8 @@
     "hardhat": "^2.12.0"
   },
   "dependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "ethers": "^5.7.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",

--- a/custom-aa/package.json
+++ b/custom-aa/package.json
@@ -14,8 +14,8 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@openzeppelin/contracts": "^4.7.3",
     "hardhat": "^2.12.0",

--- a/custom-paymaster/package.json
+++ b/custom-paymaster/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "devDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^0.1.3",
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.1",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.1",
     "@nomiclabs/hardhat-ethers": "^2.2.3",

--- a/gated-nft/zksync/package.json
+++ b/gated-nft/zksync/package.json
@@ -5,8 +5,8 @@
   "author": "Antonio <aug@matterlabs.dev>",
   "license": "MIT",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/hardhat-zksync-verify": "^0.2.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@nomicfoundation/hardhat-verify": "^1.0.3",

--- a/hello-world-docker/package.json
+++ b/hello-world-docker/package.json
@@ -5,8 +5,8 @@
   "author": "Antonio <aug@matterlabs.dev>",
   "license": "MIT",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/hardhat-zksync-verify": "^0.1.8",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@types/chai": "^4.3.4",

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -5,8 +5,8 @@
   "author": "Antonio <aug@matterlabs.dev>",
   "license": "MIT",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.1",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/hardhat-zksync-verify": "^0.1.8",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@types/chai": "^4.3.4",

--- a/spend-limit/package.json
+++ b/spend-limit/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "devDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^0.1.2",
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.1",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/hardhat-zksync-verify": "^0.1.1",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.1.5",

--- a/usdc-paymaster-w-api3-data-feeds/package.json
+++ b/usdc-paymaster-w-api3-data-feeds/package.json
@@ -5,8 +5,8 @@
   "author": "Vansh Wassan <007blackhacker@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
-    "@matterlabs/hardhat-zksync-solc": "^0.4.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@openzeppelin/contracts": "^4.8.3",
     "@openzeppelin/contracts-upgradeable": "^4.8.3",


### PR DESCRIPTION
# What :computer:

- Bumps hardhat zksync solc and deploy versions across examples

# Why :hand:

- Fetch binaries for zksolc and/or zkvyper from GH Releases CDN instead of repositories
