### PR TITLE
Use hardhat zks node

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,11 @@ jobs:
         run: |
           cd hello-world && yarn test
 
+      - name: Custom AA tests
+        run: |
+          cd custom-aa && yarn test
+
       - name: Gated NFT tests
         run: |
           cd gated-nft/zksync && yarn test
 
-      - name: Custom AA tests
-        run: |
-          cd custom-aa && yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,10 +74,6 @@ jobs:
           yarn install --frozen-lockfile
           cd gated-nft/zksync && yarn install --frozen-lockfile
 
-      - name: Custom AA tests
-        run: |
-          cd custom-aa && yarn test
-
       - name: Hello World tests
         run: |
           cd hello-world && yarn test
@@ -85,3 +81,7 @@ jobs:
       - name: Gated NFT tests
         run: |
           cd gated-nft/zksync && yarn test
+
+      - name: Custom AA tests
+        run: |
+          cd custom-aa && yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,9 +69,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Run Era Test Node
-        uses: dutterbutter/era-test-node-action@latest
-
       - name: Install dependencies
         run: |
           yarn install --frozen-lockfile

--- a/custom-aa/README.md
+++ b/custom-aa/README.md
@@ -21,4 +21,4 @@ To run the scripts to deploy and execute the contracts, use the `zksync-deploy` 
 
 ## Support
 
-Check out the [common errors section in the tutorial](https://v2-docs.zksync.io/dev/tutorials/custom-paymaster-tutorial.html#prerequisite), open an issue, or [contact us on Discord](https://discord.com/invite/px2aR7w).
+Check out the [common errors section in the tutorial](https://v2-docs.zksync.io/dev/tutorials/custom-paymaster-tutorial.html#prerequisite), open an issue, or [contact us on Discord](https://join.zksync.dev/).

--- a/custom-aa/hardhat.config.ts
+++ b/custom-aa/hardhat.config.ts
@@ -1,24 +1,19 @@
 import { HardhatUserConfig } from "hardhat/config";
-import { localConfig } from "../tests/testConfig";
 
 import "@matterlabs/hardhat-zksync-deploy";
 import "@matterlabs/hardhat-zksync-solc";
+import "@matterlabs/hardhat-zksync-node";
+
+import "@matterlabs/hardhat-zksync-verify";
+
 
 const config: HardhatUserConfig = {
   zksolc: {
     version: "latest",
-    settings: {
-      isSystem: true,
-    },
+    settings: {},
   },
-  defaultNetwork: "zkSyncTestnet",
   networks: {
     hardhat: {
-      zksync: true,
-    },
-    zkSyncTestnet: {
-      url: localConfig.L2Network,
-      ethNetwork: localConfig.L1Network, // Can also be the RPC URL of the network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
       zksync: true,
     },
   },

--- a/custom-aa/hardhat.config.ts
+++ b/custom-aa/hardhat.config.ts
@@ -6,7 +6,6 @@ import "@matterlabs/hardhat-zksync-node";
 
 import "@matterlabs/hardhat-zksync-verify";
 
-
 const config: HardhatUserConfig = {
   zksolc: {
     version: "latest",

--- a/custom-aa/package.json
+++ b/custom-aa/package.json
@@ -17,6 +17,7 @@
     "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/zksync-contracts": "^0.6.1",
+    "@matterlabs/hardhat-zksync-node": "^0.0.1-beta.4",
     "@openzeppelin/contracts": "^4.7.3",
     "hardhat": "^2.12.0",
     "zksync-web3": "^0.14.3"

--- a/custom-aa/test/utils/utils.ts
+++ b/custom-aa/test/utils/utils.ts
@@ -138,6 +138,7 @@ export class Utils {
       await tx.wait(1);
       this.txHash = tx.hash;
     } catch (e) {
+      console.log("\n\n ==== Deploy account error ==== \n\n", e);
       return e;
     }
     // Getting the address of the deployed contract account

--- a/hello-world/hardhat.config.ts
+++ b/hello-world/hardhat.config.ts
@@ -6,7 +6,6 @@ import "@matterlabs/hardhat-zksync-node";
 
 import "@matterlabs/hardhat-zksync-verify";
 
-
 const config: HardhatUserConfig = {
   zksolc: {
     version: "latest",

--- a/hello-world/hardhat.config.ts
+++ b/hello-world/hardhat.config.ts
@@ -1,39 +1,24 @@
-import { localConfig } from "../tests/testConfig";
 import { HardhatUserConfig } from "hardhat/config";
 
 import "@matterlabs/hardhat-zksync-deploy";
 import "@matterlabs/hardhat-zksync-solc";
+import "@matterlabs/hardhat-zksync-node";
 
 import "@matterlabs/hardhat-zksync-verify";
 
-// dynamically changes endpoints for local tests
-const zkSyncTestnet = {
-  url: localConfig.L2Network,
-  ethNetwork: localConfig.L1Network,
-  zksync: true,
-};
 
 const config: HardhatUserConfig = {
   zksolc: {
     version: "latest",
     settings: {},
   },
-  defaultNetwork: "zkSyncTestnet",
   networks: {
     hardhat: {
-      zksync: false,
+      zksync: true,
     },
-    zkSyncTestnet,
   },
   solidity: {
     version: "0.8.17",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
-      },
-      viaIR: true,
-    },
   },
 };
 

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -8,6 +8,7 @@
     "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/hardhat-zksync-verify": "^0.1.8",
+    "@matterlabs/hardhat-zksync-node": "^0.0.1-beta.4",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",

--- a/hello-world/test/main.test.ts
+++ b/hello-world/test/main.test.ts
@@ -5,7 +5,7 @@ describe("Greeter", function () {
   let contract: any;
   let result: string;
 
-  beforeEach(async function () {
+  before(async function () {
     contract = await deploy();
   });
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
   },
   "scripts": {
     "fix:fmt": "prettier --write .",
-    "lint:fmt": "prettier --check .",
-    "install:local:node": "cargo install --git https://github.com/matter-labs/era-test-node.git --locked",
-    "launch:local:node": "era_test_node run"
+    "lint:fmt": "prettier --check ."
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,17 @@
     chalk "4.1.2"
     ts-morph "^19.0.0"
 
+"@matterlabs/hardhat-zksync-node@^0.0.1-beta.4":
+  version "0.0.1-beta.4"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-0.0.1-beta.4.tgz#d32f548c1a5bee95d9967cf48dcb24d1b9ea1186"
+  integrity sha512-UyU3DcC5HyrjNTY/Dvqr6aIUn+Yb4NW7wQofD8bDlwnbYrEkOnowc2pIqAQ5b3JMfYWL0qTL2QJOBWLL3iRzbg==
+  dependencies:
+    "@matterlabs/hardhat-zksync-solc" "0.4.2"
+    axios "^1.4.0"
+    chalk "4.1.2"
+    fs-extra "^11.1.1"
+    ts-morph "^19.0.0"
+
 "@matterlabs/hardhat-zksync-solc@0.3.17":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-0.3.17.tgz#72f199544dc89b268d7bfc06d022a311042752fd"


### PR DESCRIPTION
# What :computer:

This PR introduces the use of the `hardhat-zksync-node` plugin to tutorials that eliminates the need to manually manage `era-test-node` for tests. 

# Why :hand:

- Starting and stopping the node manually is cumbersome and bad devex

# Evidence :camera:

<img width="590" alt="image" src="https://github.com/matter-labs/tutorials/assets/10233439/1b1972bb-a547-464d-9ff2-472124f21527">
<img width="1420" alt="image" src="https://github.com/matter-labs/tutorials/assets/10233439/321dd386-dc67-4855-971e-fdb98f8e1740">

