### PR TITLE
fix: use zksync-ethers instead of zksync-web3, update other packages

### DIFF
--- a/cross-chain/L2-counter/deploy/deploy.ts
+++ b/cross-chain/L2-counter/deploy/deploy.ts
@@ -1,4 +1,4 @@
-import { utils, Wallet } from "zksync-web3";
+import { utils, Wallet } from "zksync-ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 

--- a/cross-chain/L2-counter/package.json
+++ b/cross-chain/L2-counter/package.json
@@ -7,12 +7,12 @@
     "hardhat": "^2.12.0"
   },
   "dependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-deploy": "^0.7.0",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "ethers": "^5.7.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
-    "zksync-web3": "^0.14.3"
+    "zksync-ethers": "^5"
   },
   "scripts": {
     "start": "hardhat deploy-zksync",

--- a/cross-chain/L2-counter/scripts/display-value.ts
+++ b/cross-chain/L2-counter/scripts/display-value.ts
@@ -1,4 +1,4 @@
-import { Contract, Provider } from "zksync-web3";
+import { Contract, Provider } from "zksync-ethers";
 
 const COUNTER_ADDRESS = "<COUNTER-ADDRESS>";
 const COUNTER_ABI = require("./counter.json");

--- a/cross-chain/L2-counter/scripts/increment-counter.ts
+++ b/cross-chain/L2-counter/scripts/increment-counter.ts
@@ -1,5 +1,5 @@
 import { BigNumber, Contract, Wallet, ethers } from "ethers";
-import { Provider, utils } from "zksync-web3";
+import { Provider, utils } from "zksync-ethers";
 const GOVERNANCE_ABI = require("./governance.json");
 const GOVERNANCE_ADDRESS = "<GOVERNANCE-ADDRESS>";
 const COUNTER_ABI = require("./counter.json");

--- a/custom-aa/deploy/deploy-factory.ts
+++ b/custom-aa/deploy/deploy-factory.ts
@@ -1,5 +1,4 @@
-import { utils, Wallet } from "zksync-web3";
-import * as ethers from "ethers";
+import { utils, Wallet } from "zksync-ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 

--- a/custom-aa/deploy/deploy-multisig.ts
+++ b/custom-aa/deploy/deploy-multisig.ts
@@ -1,6 +1,6 @@
 import * as ethers from "ethers";
 
-import { EIP712Signer, Provider, Wallet, types, utils } from "zksync-web3";
+import { EIP712Signer, Provider, Wallet, types, utils } from "zksync-ethers";
 
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/custom-aa/package.json
+++ b/custom-aa/package.json
@@ -11,15 +11,15 @@
   "devDependencies": {
     "ethers": "^5.7.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "zksync-ethers": "^5"
   },
   "dependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-deploy": "^0.7.0",
+    "@matterlabs/hardhat-zksync-node": "^0.0.1",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/zksync-contracts": "^0.6.1",
-    "@matterlabs/hardhat-zksync-node": "^0.0.1-beta.6",
     "@openzeppelin/contracts": "^4.7.3",
-    "hardhat": "^2.12.0",
-    "zksync-web3": "^0.16.0"
+    "hardhat": "^2.12.0"
   }
 }

--- a/custom-aa/test/main.test.ts
+++ b/custom-aa/test/main.test.ts
@@ -4,7 +4,7 @@ import { localConfig } from "../../tests/testConfig";
 import * as eth from "ethers";
 import { Helper } from "../../tests/helper";
 import { Wallets } from "../../tests/testData";
-import * as zks from "zksync-web3";
+import * as zks from "zksync-ethers";
 
 describe("Custom AA Tests", function () {
   let result: any;

--- a/custom-aa/test/utils/utils.ts
+++ b/custom-aa/test/utils/utils.ts
@@ -1,7 +1,7 @@
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 
-import { EIP712Signer, Provider, types, utils, Wallet } from "zksync-web3";
+import { EIP712Signer, Provider, types, utils, Wallet } from "zksync-ethers";
 import { localConfig } from "../../../tests/testConfig";
 import { Contract, ethers } from "ethers";
 import { Helper } from "../../../tests/helper";

--- a/custom-paymaster/deploy/deploy-paymaster.ts
+++ b/custom-paymaster/deploy/deploy-paymaster.ts
@@ -1,6 +1,6 @@
 import * as ethers from "ethers";
 
-import { Provider, Wallet, utils } from "zksync-web3";
+import { Provider, Wallet, utils } from "zksync-ethers";
 
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { HardhatRuntimeEnvironment } from "hardhat/types";

--- a/custom-paymaster/deploy/use-paymaster.ts
+++ b/custom-paymaster/deploy/use-paymaster.ts
@@ -1,6 +1,6 @@
 import * as ethers from "ethers";
 
-import { Provider, Wallet, utils } from "zksync-web3";
+import { Provider, Wallet, utils } from "zksync-ethers";
 
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/custom-paymaster/package.json
+++ b/custom-paymaster/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "devDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^0.1.3",
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-deploy": "^0.7.0",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.1",
@@ -21,7 +21,7 @@
     "prettier": "^3.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4",
-    "zksync-web3": "^0.14.3"
+    "zksync-ethers": "^5"
   },
   "scripts": {
     "test": "NODE_ENV=test hardhat test",

--- a/custom-paymaster/test/MyERC20.test.ts
+++ b/custom-paymaster/test/MyERC20.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Wallet, Provider, Contract } from "zksync-web3";
+import { Wallet, Provider, Contract } from "zksync-ethers";
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import * as ethers from "ethers";

--- a/custom-paymaster/test/MyPaymaster.test.ts
+++ b/custom-paymaster/test/MyPaymaster.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Wallet, Provider, Contract, utils } from "zksync-web3";
+import { Wallet, Provider, Contract, utils } from "zksync-ethers";
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import * as ethers from "ethers";

--- a/custom-paymaster/test/utils.ts
+++ b/custom-paymaster/test/utils.ts
@@ -1,4 +1,4 @@
-import { Contract, Wallet } from "zksync-web3";
+import { Contract, Wallet } from "zksync-ethers";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import * as ethers from "ethers";
 

--- a/gated-nft/frontend/app/components/WalletButton.tsx
+++ b/gated-nft/frontend/app/components/WalletButton.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from "react";
-import { Web3Provider, Signer, Contract } from "zksync-web3";
+import { Web3Provider, Signer, Contract } from "zksync-ethers";
 import Web3Context from "../context/Web3Context";
 import {
   GREETER_ADDRESS,
@@ -10,7 +10,7 @@ import {
   NETWORK_ID,
 } from "../constants/consts";
 import { PowerStoneNft } from "../types/types";
-import { Address } from "zksync-web3/build/src/types";
+import { Address } from "zksync-ethers/build/src/types";
 
 function WalletComponent() {
   const web3Context = useContext(Web3Context);

--- a/gated-nft/frontend/app/context/Web3Context.tsx
+++ b/gated-nft/frontend/app/context/Web3Context.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Contract, Web3Provider, Signer } from "zksync-web3";
+import { Contract, Web3Provider, Signer } from "zksync-ethers";
 import { PowerStoneNft } from "../types/types";
 
 export interface Web3ContextType {

--- a/gated-nft/frontend/app/hooks/usePaymaster.tsx
+++ b/gated-nft/frontend/app/hooks/usePaymaster.tsx
@@ -1,4 +1,4 @@
-import { Contract, utils } from "zksync-web3";
+import { Contract, utils } from "zksync-ethers";
 import { PAYMASTER_CONTRACT_ADDRESS } from "../constants/consts";
 import { PaymasterProps } from "../types/types";
 import * as ethers from "ethers";

--- a/gated-nft/frontend/app/layout.tsx
+++ b/gated-nft/frontend/app/layout.tsx
@@ -5,7 +5,7 @@ import { Inter } from "next/font/google";
 import { useState } from "react";
 import Web3Context from "./context/Web3Context";
 import { PowerStoneNft } from "./types/powerStoneNft";
-import { Contract, Web3Provider, Signer } from "zksync-web3";
+import { Contract, Web3Provider, Signer } from "zksync-ethers";
 const inter = Inter({ subsets: ["latin"] });
 
 export default function RootLayout({

--- a/gated-nft/frontend/app/types/types.d.ts
+++ b/gated-nft/frontend/app/types/types.d.ts
@@ -1,4 +1,4 @@
-import { Contract, Web3Provider } from "zksync-web3";
+import { Contract, Web3Provider } from "zksync-ethers";
 
 type InputProps = {
   greeterInstance: Contract | null;

--- a/gated-nft/frontend/package.json
+++ b/gated-nft/frontend/package.json
@@ -20,13 +20,13 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.2",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "zksync-ethers": "^5"
   },
   "devDependencies": {
     "@headlessui/react": "^1.7.15",
     "@heroicons/react": "^2.0.18",
     "@tailwindcss/forms": "^0.5.3",
-    "ethers": "5.7.2",
-    "zksync-web3": "^0.14.3"
+    "ethers": "5.7.2"
   }
 }

--- a/gated-nft/yarn.lock
+++ b/gated-nft/yarn.lock
@@ -517,38 +517,26 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@matterlabs/hardhat-zksync-deploy@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-deploy/-/hardhat-zksync-deploy-0.6.5.tgz#fe56bf30850e71c8d328ac1a06a100c1a0af6e3e"
-  integrity sha512-EZpvn8pDslfO3UA2obT8FOi5jsHhxYS5ndIR7tjL2zXKbvkbpoJR5rgKoGTJJm0riaCud674sQcxMOybVQ+2gg==
+"@matterlabs/hardhat-zksync-deploy@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-deploy/-/hardhat-zksync-deploy-0.7.0.tgz#e56b73d8f8fbd0f809a779d0028418ea7d914017"
+  integrity sha512-PGZcuhKsVzZ2IWPt931pK2gA+HDxnCtye+7CwvoOnM6diHeO9tB1QHFX/ywR9ErOW9wpezhPYkVDx9myFrdoqQ==
   dependencies:
-    "@matterlabs/hardhat-zksync-solc" "0.4.2"
+    "@matterlabs/hardhat-zksync-solc" "^1.0.5"
     chalk "4.1.2"
     ts-morph "^19.0.0"
 
-"@matterlabs/hardhat-zksync-node@^0.0.1-beta.6":
-  version "0.0.1-beta.6"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-0.0.1-beta.6.tgz#7bfd4af1820335a10f78dee864c5b49da5a1a3bd"
-  integrity sha512-YwPkfOLm+p6YZJuta3yCgJnUM2LM+w+jOPkTyLZBS3a1G2ozWvPhOtShsSXU2M2HVHhA+ubkx/+rk6zYOZiXfQ==
+"@matterlabs/hardhat-zksync-node@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-0.0.1.tgz#d44bda3c0069b149e2a67c9697eb81166b169ea6"
+  integrity sha512-rMabl+I813lzXINqTq5OvujQ30wsfO9mTLMPDXuYzEEhEzvnXlaVxuqynKBXrgXAxjmr+G79rqvcWgeKygtwBA==
   dependencies:
-    "@matterlabs/hardhat-zksync-solc" "1.0.0"
+    "@matterlabs/hardhat-zksync-solc" "^1.0.5"
     axios "^1.4.0"
     chalk "4.1.2"
     fs-extra "^11.1.1"
-    ts-morph "^19.0.0"
 
-"@matterlabs/hardhat-zksync-solc@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-0.4.1.tgz#e8e67d947098d7bb8925f968544d34e522af5a9c"
-  integrity sha512-fdlGf/2yZR5ihVNc2ubea1R/nNFXRONL29Fgz5FwB3azB13rPb76fkQgcFIg9zSufHsEy6zUUT029NkxLNA9Sw==
-  dependencies:
-    "@nomiclabs/hardhat-docker" "^2.0.0"
-    chalk "4.1.2"
-    dockerode "^3.3.4"
-    fs-extra "^11.1.1"
-    semver "^7.5.1"
-
-"@matterlabs/hardhat-zksync-solc@0.4.2", "@matterlabs/hardhat-zksync-solc@^0.4.2":
+"@matterlabs/hardhat-zksync-solc@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-0.4.2.tgz#64121082e88c5ab22eb4e9594d120e504f6af499"
   integrity sha512-6NFWPSZiOAoo7wNuhMg4ztj7mMEH+tLrx09WuCbcURrHPijj/KxYNsJD6Uw5lapKr7G8H7SQISGid1/MTXVmXQ==
@@ -560,28 +548,29 @@
     proper-lockfile "^4.1.2"
     semver "^7.5.1"
 
-"@matterlabs/hardhat-zksync-solc@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.0.0.tgz#4da54b59fb4fa9c2ba22a3bb2e6150cf1d70028c"
-  integrity sha512-N6uUcmbAwZtu60WooUGJ1ssUdFFCd8MU1PdOSXcCJQ3vzjej2p3Ra8t3DrbJSWf3LRJoM18mZkZD2AktlF/ONw==
+"@matterlabs/hardhat-zksync-solc@^1.0.5":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.0.6.tgz#7ef8438e6bb15244691600e2afa77aaff7dff9f0"
+  integrity sha512-0icYSufXba/Bbb7v2iXuZJ+IbYsiNpR4Wy6UizHnGuFw3OMHgh+saebQphuaN9yyRL2UPGZbPkQFHWBLZj5/xQ==
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
     chalk "4.1.2"
-    dockerode "^3.3.4"
+    dockerode "^4.0.0"
     fs-extra "^11.1.1"
     proper-lockfile "^4.1.2"
     semver "^7.5.1"
 
-"@matterlabs/hardhat-zksync-verify@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-verify/-/hardhat-zksync-verify-0.2.1.tgz#f52cbe3670b7a6b01c8c4d0bbf3e6e13583e5d99"
-  integrity sha512-6awofVwsGHlyFMNTZcp05DPHpriSmmhBw0q+OC/Kn9xbdqT8E7fMJa6irvJH590UugxGerKrZDIY6uM6rwAjqQ==
+"@matterlabs/hardhat-zksync-verify@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-verify/-/hardhat-zksync-verify-0.4.0.tgz#f812c19950022fc36728f3796f6bdae5633e2fcd"
+  integrity sha512-GPZmAumFl3ZMPKbECX7Qw8CriwZKWd1DlCRhoG/6YYc6mFy4+MXkF1XsHLMs5r34N+GDOfbVZVMeftIlJC96Kg==
   dependencies:
-    "@matterlabs/hardhat-zksync-solc" "0.4.1"
+    "@matterlabs/hardhat-zksync-solc" "^1.0.5"
     "@nomicfoundation/hardhat-verify" "^1.0.2"
     axios "^1.4.0"
     chalk "4.1.2"
     dockerode "^3.3.4"
+    zksync-ethers "^5.0.0"
 
 "@matterlabs/zksync-contracts@^0.6.1":
   version "0.6.1"
@@ -1955,7 +1944,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cpu-features@~0.0.8:
+cpu-features@~0.0.8, cpu-features@~0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.9.tgz#5226b92f0f1c63122b0a3eb84cb8335a4de499fc"
   integrity sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==
@@ -2131,6 +2120,16 @@ docker-modem@^3.0.0:
     split-ca "^1.0.1"
     ssh2 "^1.11.0"
 
+docker-modem@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/docker-modem/-/docker-modem-5.0.3.tgz#50c06f11285289f58112b5c4c4d89824541c41d0"
+  integrity sha512-89zhop5YVhcPEt5FpUFGr3cDyceGhq/F9J+ZndQ4KfqNvfbJpPMfgeixFgUj5OjCYAboElqODxY5Z1EBsSa6sg==
+  dependencies:
+    debug "^4.1.1"
+    readable-stream "^3.5.0"
+    split-ca "^1.0.1"
+    ssh2 "^1.15.0"
+
 dockerode@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-2.5.8.tgz#1b661e36e1e4f860e25f56e0deabe9f87f1d0acc"
@@ -2147,6 +2146,15 @@ dockerode@^3.3.4:
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     docker-modem "^3.0.0"
+    tar-fs "~2.0.1"
+
+dockerode@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-4.0.2.tgz#dedc8529a1db3ac46d186f5912389899bc309f7d"
+  integrity sha512-9wM1BVpVMFr2Pw3eJNXrYYt6DT9k0xMcsSCjtPvyQ+xa1iPg/Mo3T/gUcwI0B2cczqCeCYRPF8yFYDwtFXT0+w==
+  dependencies:
+    "@balena/dockerignore" "^1.0.2"
+    docker-modem "^5.0.3"
     tar-fs "~2.0.1"
 
 doctrine@^2.1.0:
@@ -2588,7 +2596,7 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethers@5.7.2, ethers@^5.7.1, ethers@^5.7.2:
+ethers@5.7.2, ethers@^5.7.1, ethers@^5.7.2, ethers@~5.7.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -3833,7 +3841,7 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.17.0:
+nan@^2.17.0, nan@^2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
   integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
@@ -4693,6 +4701,17 @@ ssh2@^1.11.0:
     cpu-features "~0.0.8"
     nan "^2.17.0"
 
+ssh2@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.15.0.tgz#2f998455036a7f89e0df5847efb5421748d9871b"
+  integrity sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==
+  dependencies:
+    asn1 "^0.2.6"
+    bcrypt-pbkdf "^1.0.2"
+  optionalDependencies:
+    cpu-features "~0.0.9"
+    nan "^2.18.0"
+
 stacktrace-parser@^0.1.10:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
@@ -5394,10 +5413,12 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.14.3:
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.4.tgz#0b70a7e1a9d45cc57c0971736079185746d46b1f"
-  integrity sha512-kYehMD/S6Uhe1g434UnaMN+sBr9nQm23Ywn0EUP5BfQCsbjcr3ORuS68PosZw8xUTu3pac7G6YMSnNHk+fwzvg==
+zksync-ethers@^5, zksync-ethers@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/zksync-ethers/-/zksync-ethers-5.0.0.tgz#2d0bb9a98ad1198957038f7669a50b10ef96bc3c"
+  integrity sha512-zPowwK/2wG3YqIlKNtRfzpMnHMnWSa5wFsfDrxKFgLjbA3VvuHl4mFCFUxMapsroGyG619+zt71HKM1jyNpSmQ==
+  dependencies:
+    ethers "~5.7.0"
 
 zod@3.21.4:
   version "3.21.4"

--- a/gated-nft/zksync/deploy/deploy-ERC721.ts
+++ b/gated-nft/zksync/deploy/deploy-ERC721.ts
@@ -1,4 +1,4 @@
-import { Provider, Wallet } from "zksync-web3";
+import { Provider, Wallet } from "zksync-ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import * as fs from "fs";

--- a/gated-nft/zksync/deploy/deploy-ERC721GatedPaymaster.ts
+++ b/gated-nft/zksync/deploy/deploy-ERC721GatedPaymaster.ts
@@ -1,7 +1,7 @@
 import * as ethers from "ethers";
 import * as fs from "fs";
 
-import { Provider, Wallet } from "zksync-web3";
+import { Provider, Wallet } from "zksync-ethers";
 
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { HardhatRuntimeEnvironment } from "hardhat/types";

--- a/gated-nft/zksync/deploy/deploy-greeter.ts
+++ b/gated-nft/zksync/deploy/deploy-greeter.ts
@@ -1,4 +1,4 @@
-import { Wallet, utils } from "zksync-web3";
+import { Wallet, utils } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";

--- a/gated-nft/zksync/package.json
+++ b/gated-nft/zksync/package.json
@@ -5,11 +5,11 @@
   "author": "Antonio <aug@matterlabs.dev>",
   "license": "MIT",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-deploy": "^0.7.0",
+    "@matterlabs/hardhat-zksync-node": "^0.0.1",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
-    "@matterlabs/hardhat-zksync-verify": "^0.2.0",
+    "@matterlabs/hardhat-zksync-verify": "^0.4.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
-    "@matterlabs/hardhat-zksync-node": "^0.0.1-beta.6",
     "@nomicfoundation/hardhat-verify": "^1.0.3",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@openzeppelin/contracts": "^4.9.2",
@@ -23,7 +23,7 @@
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
-    "zksync-web3": "^0.16.0"
+    "zksync-ethers": "^5"
   },
   "scripts": {
     "test": "hardhat test",

--- a/gated-nft/zksync/test/utils/deploy-ERC721GatedPaymaster.ts
+++ b/gated-nft/zksync/test/utils/deploy-ERC721GatedPaymaster.ts
@@ -1,7 +1,7 @@
 import * as ethers from "ethers";
 import * as fs from "fs";
 
-import { Provider, Wallet } from "zksync-web3";
+import { Provider, Wallet } from "zksync-ethers";
 
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { HardhatRuntimeEnvironment } from "hardhat/types";

--- a/gated-nft/zksync/test/utils/deploy-greeter.ts
+++ b/gated-nft/zksync/test/utils/deploy-greeter.ts
@@ -1,5 +1,5 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { Wallet, Provider } from "zksync-web3";
+import { Wallet, Provider } from "zksync-ethers";
 import * as ethers from "ethers";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import * as fs from "fs";

--- a/gated-nft/zksync/test/utils/utils.ts
+++ b/gated-nft/zksync/test/utils/utils.ts
@@ -1,6 +1,6 @@
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
-import { Provider, Wallet } from "zksync-web3";
+import { Provider, Wallet } from "zksync-ethers";
 import { localConfig } from "../../../../tests/testConfig";
 import { ethers } from "ethers";
 import * as fs from "fs";

--- a/hello-world-docker/deploy/deploy-greeter.ts
+++ b/hello-world-docker/deploy/deploy-greeter.ts
@@ -1,4 +1,4 @@
-import { Wallet, utils } from "zksync-web3";
+import { Wallet, utils } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";

--- a/hello-world-docker/deploy/use-greeter.ts
+++ b/hello-world-docker/deploy/use-greeter.ts
@@ -1,4 +1,4 @@
-import { Provider } from "zksync-web3";
+import { Provider } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/hello-world-docker/package.json
+++ b/hello-world-docker/package.json
@@ -5,9 +5,9 @@
   "author": "Antonio <aug@matterlabs.dev>",
   "license": "MIT",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-deploy": "^0.7.0",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
-    "@matterlabs/hardhat-zksync-verify": "^0.1.8",
+    "@matterlabs/hardhat-zksync-verify": "^0.4.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",
@@ -18,7 +18,7 @@
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
-    "zksync-web3": "^0.14.3"
+    "zksync-ethers": "^5"
   },
   "scripts": {
     "test": "NODE_ENV=test hardhat test --network zkSyncTestnet",

--- a/hello-world-docker/test/main.test.ts
+++ b/hello-world-docker/test/main.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Wallet, Provider, Contract } from "zksync-web3";
+import { Wallet, Provider, Contract } from "zksync-ethers";
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 

--- a/hello-world/deploy/deploy-greeter.ts
+++ b/hello-world/deploy/deploy-greeter.ts
@@ -1,4 +1,4 @@
-import { Wallet, utils } from "zksync-web3";
+import { Wallet, utils } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";

--- a/hello-world/deploy/use-greeter.ts
+++ b/hello-world/deploy/use-greeter.ts
@@ -1,4 +1,4 @@
-import { Provider } from "zksync-web3";
+import { Provider } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -5,10 +5,10 @@
   "author": "Antonio <aug@matterlabs.dev>",
   "license": "MIT",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-deploy": "^0.7.0",
+    "@matterlabs/hardhat-zksync-node": "^0.0.1",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
-    "@matterlabs/hardhat-zksync-verify": "^0.1.8",
-    "@matterlabs/hardhat-zksync-node": "^0.0.1-beta.6",
+    "@matterlabs/hardhat-zksync-verify": "^0.4.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",
@@ -19,7 +19,7 @@
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
-    "zksync-web3": "^0.16.0"
+    "zksync-ethers": "^5"
   },
   "scripts": {
     "test": "hardhat test",

--- a/hello-world/test/utils/utils.ts
+++ b/hello-world/test/utils/utils.ts
@@ -1,4 +1,4 @@
-import { Wallet, Provider, Contract } from "zksync-web3";
+import { Wallet, Provider, Contract } from "zksync-ethers";
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { Wallets } from "../../../tests/testData";

--- a/spend-limit/TUTORIAL.md
+++ b/spend-limit/TUTORIAL.md
@@ -20,7 +20,7 @@ First, let’s install all the dependencies that we'll need:
 mkdir custom-spendlimit-tutorial
 cd custom-spendlimit-tutorial
 yarn init -y
-yarn add -D typescript ts-node ethers zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
+yarn add -D typescript ts-node ethers zksync-ethers hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
 ```
 
 Additionally, please install a few packages that allow us to utilize the [zkSync smart contracts](https://v2-docs.zksync.io/dev/developer-guides/contracts/system-contracts.html).
@@ -517,7 +517,7 @@ if ( value > 0 ) {
 
 Since we want to set the spending limit of ETH in this example, the first argument in `_checkSpendingLimit` should be `address(ETH_TOKEN_SYSTEM_CONTRACT)`, which is imported from a system contract called `system-contracts/Constant.sol`.
 
-**Note1** : The formal ETH address on zkSync is `0x000000000000000000000000000000000000800a`, neither the well-known `0xEee...EEeE` used by protocols as a placeholder on Ethereum, nor the zero address `0x000...000`, which is what `zksync-web3` package([See](https://v2-docs.zksync.io/api/js/utils.html#the-address-of-ether)) provides as a more user-friendly alias.
+**Note1** : The formal ETH address on zkSync is `0x000000000000000000000000000000000000800a`, neither the well-known `0xEee...EEeE` used by protocols as a placeholder on Ethereum, nor the zero address `0x000...000`, which is what `zksync-ethers` package([See](https://v2-docs.zksync.io/api/js/utils.html#the-address-of-ether)) provides as a more user-friendly alias.
 
 **Note2** : SpendLimit is token-agnostic. Thus an extension is also possible: add a check for whether or not the execution is an ERC20 transfer by extracting the function selector in bytes from transaction calldata.
 
@@ -573,7 +573,7 @@ yarn hardhat compile
 Then, let's create a file `deploy-factory-account.ts` that deploys all the contracts we've made above and creates an account.
 
 ```typescript
-import { utils, Wallet, Provider } from "zksync-web3";
+import { utils, Wallet, Provider } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
@@ -669,7 +669,7 @@ import {
   Contract,
   EIP712Signer,
   types,
-} from "zksync-web3";
+} from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -746,7 +746,7 @@ import {
   Contract,
   EIP712Signer,
   types,
-} from "zksync-web3";
+} from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -875,5 +875,5 @@ You can download the complete project [here](https://github.com/porco-rosso-j/da
 ## Learn more
 
 - To learn more about L1->L2 interaction on zkSync, check out the [documentation](https://v2-docs.zksync.io/dev/developer-guides/bridging/l1-l2.html).
-- To learn more about the zksync-web3 SDK, check out its [documentation](https://v2-docs.zksync.io/api/js).
+- To learn more about the zksync-ethers SDK, check out its [documentation](https://v2-docs.zksync.io/api/js).
 - To learn more about the zkSync hardhat plugins, check out their [documentation](https://v2-docs.zksync.io/api/hardhat).

--- a/spend-limit/deploy/deployFactoryAccount.ts
+++ b/spend-limit/deploy/deployFactoryAccount.ts
@@ -1,4 +1,4 @@
-import { utils, Wallet, Provider } from "zksync-web3";
+import { utils, Wallet, Provider } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";

--- a/spend-limit/deploy/setLimit.ts
+++ b/spend-limit/deploy/setLimit.ts
@@ -5,7 +5,7 @@ import {
   Contract,
   EIP712Signer,
   types,
-} from "zksync-web3";
+} from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/spend-limit/deploy/transferETH.ts
+++ b/spend-limit/deploy/transferETH.ts
@@ -5,7 +5,7 @@ import {
   Contract,
   EIP712Signer,
   types,
-} from "zksync-web3";
+} from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/spend-limit/package.json
+++ b/spend-limit/package.json
@@ -7,9 +7,9 @@
   "license": "MIT",
   "devDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^0.1.2",
-    "@matterlabs/hardhat-zksync-deploy": "^0.6.5",
+    "@matterlabs/hardhat-zksync-deploy": "^0.7.0",
     "@matterlabs/hardhat-zksync-solc": "^0.4.2",
-    "@matterlabs/hardhat-zksync-verify": "^0.1.1",
+    "@matterlabs/hardhat-zksync-verify": "^0.4.0",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.1.5",
     "@types/chai": "^4.3.4",
@@ -21,7 +21,7 @@
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
-    "zksync-web3": "^0.14.3"
+    "zksync-ethers": "^5"
   },
   "dependencies": {
     "@matterlabs/zksync-contracts": "^0.6.1",

--- a/spend-limit/test/spend-limit.test.ts
+++ b/spend-limit/test/spend-limit.test.ts
@@ -1,4 +1,4 @@
-import { Wallet, Provider, Contract, utils } from "zksync-web3";
+import { Wallet, Provider, Contract, utils } from "zksync-ethers";
 import { expect } from "chai";
 import * as ethers from "ethers";
 

--- a/spend-limit/test/utils/deploy.ts
+++ b/spend-limit/test/utils/deploy.ts
@@ -1,4 +1,4 @@
-import { Wallet, Contract, utils } from "zksync-web3";
+import { Wallet, Contract, utils } from "zksync-ethers";
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { ethers } from "ethers";

--- a/spend-limit/test/utils/helper.ts
+++ b/spend-limit/test/utils/helper.ts
@@ -1,5 +1,5 @@
 import { ethers, BigNumber } from "ethers";
-import { Wallet } from "zksync-web3";
+import { Wallet } from "zksync-ethers";
 
 export const toBN = (x: string): BigNumber => {
   return ethers.utils.parseEther(x);

--- a/spend-limit/test/utils/sendtx.ts
+++ b/spend-limit/test/utils/sendtx.ts
@@ -5,7 +5,7 @@ import {
   utils,
   EIP712Signer,
   types,
-} from "zksync-web3";
+} from "zksync-ethers";
 import { ethers } from "ethers";
 
 export async function sendTx(

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,36 +603,26 @@
   resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-chai-matchers/-/hardhat-zksync-chai-matchers-0.1.4.tgz#105cb0ec1367c8fcd3ce7e3773f747c71fff675b"
   integrity sha512-eGQWiImg51fmayoQ7smIK/T6QZkSu38PK7xjp1RIrewGzw2ZgqFWGp40jb5oomkf8yOQPk52Hu4TwE3Ntp8CtA==
 
-"@matterlabs/hardhat-zksync-deploy@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-deploy/-/hardhat-zksync-deploy-0.6.5.tgz#fe56bf30850e71c8d328ac1a06a100c1a0af6e3e"
-  integrity sha512-EZpvn8pDslfO3UA2obT8FOi5jsHhxYS5ndIR7tjL2zXKbvkbpoJR5rgKoGTJJm0riaCud674sQcxMOybVQ+2gg==
+"@matterlabs/hardhat-zksync-deploy@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-deploy/-/hardhat-zksync-deploy-0.7.0.tgz#e56b73d8f8fbd0f809a779d0028418ea7d914017"
+  integrity sha512-PGZcuhKsVzZ2IWPt931pK2gA+HDxnCtye+7CwvoOnM6diHeO9tB1QHFX/ywR9ErOW9wpezhPYkVDx9myFrdoqQ==
   dependencies:
-    "@matterlabs/hardhat-zksync-solc" "0.4.2"
+    "@matterlabs/hardhat-zksync-solc" "^1.0.5"
     chalk "4.1.2"
     ts-morph "^19.0.0"
 
-"@matterlabs/hardhat-zksync-node@^0.0.1-beta.6":
-  version "0.0.1-beta.6"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-0.0.1-beta.6.tgz#7bfd4af1820335a10f78dee864c5b49da5a1a3bd"
-  integrity sha512-YwPkfOLm+p6YZJuta3yCgJnUM2LM+w+jOPkTyLZBS3a1G2ozWvPhOtShsSXU2M2HVHhA+ubkx/+rk6zYOZiXfQ==
+"@matterlabs/hardhat-zksync-node@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-0.0.1.tgz#d44bda3c0069b149e2a67c9697eb81166b169ea6"
+  integrity sha512-rMabl+I813lzXINqTq5OvujQ30wsfO9mTLMPDXuYzEEhEzvnXlaVxuqynKBXrgXAxjmr+G79rqvcWgeKygtwBA==
   dependencies:
-    "@matterlabs/hardhat-zksync-solc" "1.0.0"
+    "@matterlabs/hardhat-zksync-solc" "^1.0.5"
     axios "^1.4.0"
     chalk "4.1.2"
     fs-extra "^11.1.1"
-    ts-morph "^19.0.0"
 
-"@matterlabs/hardhat-zksync-solc@0.3.17":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-0.3.17.tgz#72f199544dc89b268d7bfc06d022a311042752fd"
-  integrity sha512-aZgQ0yfXW5xPkfuEH1d44ncWV4T2LzKZd0VVPo4PL5cUrYs2/II1FaEDp5zsf3FxOR1xT3mBsjuSrtJkk4AL8Q==
-  dependencies:
-    "@nomiclabs/hardhat-docker" "^2.0.0"
-    chalk "4.1.2"
-    dockerode "^3.3.4"
-
-"@matterlabs/hardhat-zksync-solc@0.4.2", "@matterlabs/hardhat-zksync-solc@^0.4.2":
+"@matterlabs/hardhat-zksync-solc@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-0.4.2.tgz#64121082e88c5ab22eb4e9594d120e504f6af499"
   integrity sha512-6NFWPSZiOAoo7wNuhMg4ztj7mMEH+tLrx09WuCbcURrHPijj/KxYNsJD6Uw5lapKr7G8H7SQISGid1/MTXVmXQ==
@@ -644,27 +634,29 @@
     proper-lockfile "^4.1.2"
     semver "^7.5.1"
 
-"@matterlabs/hardhat-zksync-solc@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.0.0.tgz#4da54b59fb4fa9c2ba22a3bb2e6150cf1d70028c"
-  integrity sha512-N6uUcmbAwZtu60WooUGJ1ssUdFFCd8MU1PdOSXcCJQ3vzjej2p3Ra8t3DrbJSWf3LRJoM18mZkZD2AktlF/ONw==
+"@matterlabs/hardhat-zksync-solc@^1.0.5":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.0.6.tgz#7ef8438e6bb15244691600e2afa77aaff7dff9f0"
+  integrity sha512-0icYSufXba/Bbb7v2iXuZJ+IbYsiNpR4Wy6UizHnGuFw3OMHgh+saebQphuaN9yyRL2UPGZbPkQFHWBLZj5/xQ==
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
     chalk "4.1.2"
-    dockerode "^3.3.4"
+    dockerode "^4.0.0"
     fs-extra "^11.1.1"
     proper-lockfile "^4.1.2"
     semver "^7.5.1"
 
-"@matterlabs/hardhat-zksync-verify@^0.1.1", "@matterlabs/hardhat-zksync-verify@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-verify/-/hardhat-zksync-verify-0.1.8.tgz#0f975bb6354c8762e6d2f5b683453e3dc11dbbab"
-  integrity sha512-Ss8smBeX/h58NOaGQwQCGdYjkcQE9C0BX+iak5fWt49E58mDunnMsVhVogkWqO1QWq0LsdKLAuQO3blbvgVzFQ==
+"@matterlabs/hardhat-zksync-verify@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-verify/-/hardhat-zksync-verify-0.4.0.tgz#f812c19950022fc36728f3796f6bdae5633e2fcd"
+  integrity sha512-GPZmAumFl3ZMPKbECX7Qw8CriwZKWd1DlCRhoG/6YYc6mFy4+MXkF1XsHLMs5r34N+GDOfbVZVMeftIlJC96Kg==
   dependencies:
-    "@matterlabs/hardhat-zksync-solc" "0.3.17"
+    "@matterlabs/hardhat-zksync-solc" "^1.0.5"
+    "@nomicfoundation/hardhat-verify" "^1.0.2"
     axios "^1.4.0"
     chalk "4.1.2"
     dockerode "^3.3.4"
+    zksync-ethers "^5.0.0"
 
 "@matterlabs/zksync-contracts@^0.5.1":
   version "0.5.2"
@@ -889,6 +881,21 @@
     chai-as-promised "^7.1.1"
     deep-eql "^4.0.1"
     ordinal "^1.0.3"
+
+"@nomicfoundation/hardhat-verify@^1.0.2":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.1.1.tgz#6a433d777ce0172d1f0edf7f2d3e1df14b3ecfc1"
+  integrity sha512-9QsTYD7pcZaQFEA3tBb/D/oCStYDiEVDN7Dxeo/4SCyHRSm86APypxxdOMEPlGmXsAvd+p1j/dTODcpxb8aztA==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^8.1.0"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    lodash.clonedeep "^4.5.0"
+    semver "^6.3.0"
+    table "^6.8.0"
+    undici "^5.14.0"
 
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1":
   version "0.1.1"
@@ -3271,7 +3278,7 @@ cosmiconfig@^8.0.0:
     parse-json "^5.2.0"
     path-type "^4.0.0"
 
-cpu-features@~0.0.8:
+cpu-features@~0.0.8, cpu-features@~0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.9.tgz#5226b92f0f1c63122b0a3eb84cb8335a4de499fc"
   integrity sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==
@@ -3612,6 +3619,16 @@ docker-modem@^3.0.0:
     split-ca "^1.0.1"
     ssh2 "^1.11.0"
 
+docker-modem@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/docker-modem/-/docker-modem-5.0.3.tgz#50c06f11285289f58112b5c4c4d89824541c41d0"
+  integrity sha512-89zhop5YVhcPEt5FpUFGr3cDyceGhq/F9J+ZndQ4KfqNvfbJpPMfgeixFgUj5OjCYAboElqODxY5Z1EBsSa6sg==
+  dependencies:
+    debug "^4.1.1"
+    readable-stream "^3.5.0"
+    split-ca "^1.0.1"
+    ssh2 "^1.15.0"
+
 dockerode@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-2.5.8.tgz#1b661e36e1e4f860e25f56e0deabe9f87f1d0acc"
@@ -3628,6 +3645,15 @@ dockerode@^3.3.4:
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     docker-modem "^3.0.0"
+    tar-fs "~2.0.1"
+
+dockerode@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-4.0.2.tgz#dedc8529a1db3ac46d186f5912389899bc309f7d"
+  integrity sha512-9wM1BVpVMFr2Pw3eJNXrYYt6DT9k0xMcsSCjtPvyQ+xa1iPg/Mo3T/gUcwI0B2cczqCeCYRPF8yFYDwtFXT0+w==
+  dependencies:
+    "@balena/dockerignore" "^1.0.2"
+    docker-modem "^5.0.3"
     tar-fs "~2.0.1"
 
 doctrine@^2.1.0:
@@ -6386,6 +6412,11 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -6883,7 +6914,7 @@ multihashes@^0.4.15, multihashes@~0.4.15:
     multibase "^0.7.0"
     varint "^5.0.0"
 
-nan@^2.17.0:
+nan@^2.17.0, nan@^2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
   integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
@@ -8491,6 +8522,17 @@ ssh2@^1.11.0:
     cpu-features "~0.0.8"
     nan "^2.17.0"
 
+ssh2@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.15.0.tgz#2f998455036a7f89e0df5847efb5421748d9871b"
+  integrity sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==
+  dependencies:
+    asn1 "^0.2.6"
+    bcrypt-pbkdf "^1.0.2"
+  optionalDependencies:
+    cpu-features "~0.0.9"
+    nan "^2.18.0"
+
 sshpk@^1.7.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
@@ -9959,14 +10001,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.3.tgz#64ac2a16d597464c3fc4ae07447a8007631c57c9"
-  integrity sha512-hT72th4AnqyLW1d5Jlv8N2B/qhEnl2NePK2A3org7tAa24niem/UAaHMkEvmWI3SF9waYUPtqAtjpf+yvQ9zvQ==
-
-zksync-web3@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.16.0.tgz#407b258e61923d104864cff284bb54dc8b6af753"
-  integrity sha512-ER/qDpuRkoHrqwi2f4RCP6HXCQP1KB9o7Ih2K7h+QzfCSyDRL0apPMT9LkVQspeIeqRoXhl+1tit3vQdDIGe4w==
+zksync-ethers@^5, zksync-ethers@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/zksync-ethers/-/zksync-ethers-5.0.0.tgz#2d0bb9a98ad1198957038f7669a50b10ef96bc3c"
+  integrity sha512-zPowwK/2wG3YqIlKNtRfzpMnHMnWSa5wFsfDrxKFgLjbA3VvuHl4mFCFUxMapsroGyG619+zt71HKM1jyNpSmQ==
   dependencies:
     ethers "~5.7.0"


### PR DESCRIPTION
# What :computer:

- Use zksync-ethers@^5 instead of zksync-web3
- Update hardhat modules to the latest version

# Why :hand:

- zksync-web3 package is deprecated
- Updated hardhat modules to versions that use zksync-ethers as well

# Evidence :camera:
N/A