### PR TITLE
fix: use sepolia for hello world

### DIFF
--- a/hello-world/frontend/src/App.vue
+++ b/hello-world/frontend/src/App.vue
@@ -208,7 +208,7 @@ export default {
       window.ethereum
         .request({ method: "eth_requestAccounts" })
         .then(() => {
-          if (+window.ethereum.networkVersion == 280) {
+          if (+window.ethereum.networkVersion == 300) {
             this.loadMainScreen();
           } else {
             alert("Please switch network to zkSync!");


### PR DESCRIPTION
# What :computer:

- Updated current Metamask network `if` statement to check for chain id 300 (zkSync Sepolia).

# Why :hand:

- The [whole documentation](https://docs.zksync.io/build/quick-start/hello-world.html#working-with-a-web3-provider) makes references to Sepolia, but the Metamask condition is still checking for zkSync Goerli. I spent a few minutes trying to figure out the issue.

# Evidence :camera:

* I don't think this is needed.

# Notes :memo:

-  I didn't find contribution guidelines, let me know if this is the right channel.