### PR TITLE
fix: inconsistency for port specified in tutorial

### DIFF
--- a/hello-world/frontend/vite.config.ts
+++ b/hello-world/frontend/vite.config.ts
@@ -4,4 +4,7 @@ import vue from "@vitejs/plugin-vue";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  server: {
+    port: 8080,
+  },
 });


### PR DESCRIPTION

# What :computer:
- The default port has been changed to 8080.

# Why :hand:
- The port mentioned in the  [tutorial](https://docs.zksync.io/build/tutorials/dapp-development/frontend-quickstart-paymaster.html#setup-the-project) is 8080

# Notes :memo:

- 
