### PR TITLE
fix(security): executeTransactionFromOutside validation doesn't work

### DIFF
--- a/custom-aa/contracts/TwoUserMultisig.sol
+++ b/custom-aa/contracts/TwoUserMultisig.sol
@@ -114,7 +114,9 @@ contract TwoUserMultisig is IAccount, IERC1271 {
         external
         payable
     {
-        _validateTransaction(bytes32(0), _transaction);
+        bytes4 magic = _validateTransaction(bytes32(0), _transaction);
+        require(magic == ACCOUNT_VALIDATION_SUCCESS_MAGIC, "NOT VALIDATED");
+
         _executeTransaction(_transaction);
     }
 

--- a/spend-limit/TUTORIAL.md
+++ b/spend-limit/TUTORIAL.md
@@ -467,7 +467,8 @@ contract Account is IAccount, IERC1271, SpendLimit { // imports SpendLimit contr
         external
         payable
     {
-        _validateTransaction(bytes32(0), _transaction);
+        bytes4 magic = _validateTransaction(bytes32(0), _transaction);
+        require(magic == ACCOUNT_VALIDATION_SUCCESS_MAGIC, "NOT VALIDATED");
 
         _executeTransaction(_transaction);
     }

--- a/spend-limit/contracts/Account.sol
+++ b/spend-limit/contracts/Account.sol
@@ -136,7 +136,9 @@ contract Account is IAccount, IERC1271, SpendLimit {
     function executeTransactionFromOutside(
         Transaction calldata _transaction
     ) external payable {
-        _validateTransaction(bytes32(0), _transaction);
+        bytes4 magic = _validateTransaction(bytes32(0), _transaction);
+        require(magic == ACCOUNT_VALIDATION_SUCCESS_MAGIC, "NOT VALIDATED");
+
         _executeTransaction(_transaction);
     }
 

--- a/spend-limit/contracts/test/TestAccount.sol
+++ b/spend-limit/contracts/test/TestAccount.sol
@@ -136,7 +136,9 @@ contract TestAccount is IAccount, IERC1271, TestSpendLimit {
     function executeTransactionFromOutside(
         Transaction calldata _transaction
     ) external payable {
-        _validateTransaction(bytes32(0), _transaction);
+        bytes4 magic = _validateTransaction(bytes32(0), _transaction);
+        require(magic == ACCOUNT_VALIDATION_SUCCESS_MAGIC, "NOT VALIDATED");
+
         _executeTransaction(_transaction);
     }
 


### PR DESCRIPTION
# What :computer:

- Fix proper validation for `executeTransactionFromOutside`

# Why :hand:

- `executeTransactionFromOutside` didn't actually check transaction verification result

# Notes :memo:

- Related to https://github.com/matter-labs/zksync-web-era-docs/pull/997
