### PR TITLE
fix: GitHub syntax highlighting for revert message

### DIFF
--- a/custom-paymaster/contracts/MyPaymaster.sol
+++ b/custom-paymaster/contracts/MyPaymaster.sol
@@ -83,7 +83,7 @@ contract MyPaymaster is IPaymaster {
                 // If the revert reason is empty or represented by just a function selector,
                 // we replace the error with a more user-friendly message
                 if (revertReason.length <= 4) {
-                    revert("Failed to transferFrom from users' account");
+                    revert("Failed to transferFrom from user\'s account");
                 } else {
                     assembly {
                         revert(add(0x20, revertReason), mload(revertReason))


### PR DESCRIPTION
This pull request fixes a syntax highlighting issue observed on GitHub, where the possessive form "user's" within a revert message caused the rest of the Solidity code to be highlighted as a comment due to the single quote character.

Two potential solutions are provided:

1. Escape the apostrophe within the string (currently implemented in this PR). While this approach is not required by Solidity, it ensures that the code is displayed correctly when viewed on GitHub.

2. Change the possessive "user's" to the plural "users", which also avoids the GitHub highlighting issue and retains the intended meaning.

Changes:
- Escaped the apostrophe in the revert message within the `validateAndPayForPaymasterTransaction` function.

Alternative:
- The message "Failed to transferFrom from user's account" can also be altered to "Failed to transferFrom from users account", which avoids the need for an apostrophe altogether.

Problem:
![image](https://github.com/matter-labs/tutorials/assets/120671243/d12b11f1-57f6-4592-8d98-6a21a4e83530)
